### PR TITLE
Fix: page_load() is now also called on pages that don't exist

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -3,7 +3,10 @@ from wikitexthtml import Page
 
 def test_page_not_found():
     class PageTest(Page):
+        def page_load(self, page: str) -> str:
+            return "page_load() called"
+
         def page_exists(self, page: str) -> bool:
             return False
 
-    assert PageTest("Test").render().html == "<h2>Page Test not found</h2>"
+    assert PageTest("Test").render().html == "<p>page_load() called</p>"

--- a/wikitexthtml/page.py
+++ b/wikitexthtml/page.py
@@ -76,10 +76,6 @@ class Page(WikiTextHtml):
         return postprocess.replace(self, wtp.string)
 
     def render(self, body: str = None) -> "Page":
-        if not self.page_exists(self._page):
-            self._html = f"<h2>Page {self._page} not found</h2>"
-            return self
-
         body = self.page_load(self._page)
         wtp = self.prepare(body)
         self._html = self.render_page(wtp)


### PR DESCRIPTION
This means that the page_load() can return a "File does not exist"
message, instead of a hardcoded one in this library.