### PR TITLE
Fix: process an empty namespace the same as no namespace for wikilinks

### DIFF
--- a/wikitexthtml/render/wikilink.py
+++ b/wikitexthtml/render/wikilink.py
@@ -33,6 +33,10 @@ def replace(instance: WikiTextHtml, wikitext: wikitextparser.WikiText):
 
                 if WIKILINK_NAMESPACES[namespace](instance, wikilink):
                     continue
+            elif ":" in title:
+                # The wikilink starts with a :; this has the same meaning as
+                # no :, so strip it and the rest will do its thing correctly.
+                wikilink.title = wikilink.title[1:]
 
             internal.replace(instance, wikilink)
 


### PR DESCRIPTION
In other words: [[:bla]] now means the same as [[bla]]. This is
not ideal, and should be left to the user of this library to decide
what to do, but for now it resolves several issues.