### PR TITLE
Add: allow implementor to raise errors if links/templates are invalid

### DIFF
--- a/wikitexthtml/exceptions.py
+++ b/wikitexthtml/exceptions.py
@@ -1,0 +1,6 @@
+class InvalidWikiLink(Exception):
+    """Raised if a wikilink is invalid, indicating it should render as [[...]]."""
+
+
+class InvalidTemplate(Exception):
+    """Raised if a template name is invalid, indicating it should render as {{...}}."""

--- a/wikitexthtml/page.py
+++ b/wikitexthtml/page.py
@@ -87,6 +87,8 @@ class Page(WikiTextHtml):
 
     def _replace_snippets(self, wikitext: wikitextparser.WikiText, stage: str):
         for template_ in reversed(wikitext.templates):
+            if template_.name != "__snippet":
+                continue
             if template_.arguments[0].value != stage:
                 continue
 

--- a/wikitexthtml/render/parser_function.py
+++ b/wikitexthtml/render/parser_function.py
@@ -40,7 +40,7 @@ def replace(instance: WikiTextHtml, wikitext: wikitextparser.WikiText):
         name = parser_function.name.lower().strip()
 
         if name not in PARSER_FUNCTIONS:
-            instance.add_error(f"Parser function '{parser_function.name}' does not exist")
+            instance.add_error(f'Parser function "{parser_function.name}" does not exist.')
             continue
 
         PARSER_FUNCTIONS[name](instance, parser_function)

--- a/wikitexthtml/render/parser_functions/variables.py
+++ b/wikitexthtml/render/parser_functions/variables.py
@@ -3,6 +3,7 @@ import html
 import wikitextparser
 
 from .exceptions import ParserFunctionWrongArgumentCount
+from ...exceptions import InvalidWikiLink
 from ...prototype import WikiTextHtml
 
 
@@ -16,6 +17,11 @@ def variable(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunct
     elif name in ("pagename", "fullpagename", "basepagename"):
         parser_function.string = html.escape(instance.page)
     elif name == "subpagename":
-        parser_function.string = html.escape(instance.clean_title(instance.page))
+        try:
+            parser_function.string = html.escape(instance.clean_title(instance.page))
+        except InvalidWikiLink as e:
+            # Errors always end with a dot, hence the [:-1].
+            instance.add_error(f'{e.args[0][:-1]} (parserfunction "{parser_function.string}").')
+            parser_function.string = ""
     elif name == "namespace":
         parser_function.string = ""

--- a/wikitexthtml/render/table.py
+++ b/wikitexthtml/render/table.py
@@ -12,7 +12,7 @@ def _render_table(instance: WikiTextHtml, table: wikitextparser.Table):
         if attr == "style":
             style = html.escape(value, quote=False).replace('"', "'").strip()
             if not style:
-                instance.add_error(f"Table attribute '{attr}' has an empty value, which was not expected")
+                instance.add_error(f'Table attribute "{attr}" has an empty value, which was not expected.')
             elif not style.endswith(";"):
                 style += ";"
             table_style += f"{style} "
@@ -28,14 +28,14 @@ def _render_table(instance: WikiTextHtml, table: wikitextparser.Table):
         ):
             value = html.escape(value).strip()
             if not value:
-                instance.add_error(f"Table attribute '{attr}' has an empty value, which was not expected")
+                instance.add_error(f'Table attribute "{attr}" has an empty value, which was not expected.')
             else:
                 table_extra += f' {attr}="{value}"'
         elif attr in ("bordercolor", "padding"):
             # Nobody likes these attributes; just ignore it
             pass
         else:
-            instance.add_error(f"Table attribute '{attr}' is not a valid attribute")
+            instance.add_error(f'Table attribute "{attr}" is not a valid attribute.')
 
     if table_style:
         table_style = f' style="{table_style[:-1]}"'
@@ -62,20 +62,20 @@ def _render_table(instance: WikiTextHtml, table: wikitextparser.Table):
                 if attr == "style":
                     style = html.escape(value, quote=False).replace('"', "'").strip()
                     if not style:
-                        instance.add_error(f"Cell attribute '{attr}' has an empty value, which was not expected")
+                        instance.add_error(f'Cell attribute "{attr}" has an empty value, which was not expected.')
                     elif not style.endswith(";"):
                         style += ";"
                     cell_style += f"{style} "
                 elif attr in ("align", "bgcolor", "class", "colspan", "height", "rowspan", "scope", "valign", "width"):
                     value = html.escape(value).strip()
                     if not value:
-                        instance.add_error(f"Cell attribute '{attr}' has an empty value, which was not expected")
+                        instance.add_error(f'Cell attribute "{attr}" has an empty value, which was not expected.')
                     else:
                         cell_extra += f' {attr}="{value}"'
                 elif attr in ("nowrap",):
                     cell_extra += f" {attr}"
                 else:
-                    instance.add_error(f"Cell attribute '{attr}' is not a valid attribute")
+                    instance.add_error(f'Cell attribute "{attr}" is not a valid attribute.')
 
             if cell_style:
                 cell_style = f' style="{cell_style[:-1]}"'

--- a/wikitexthtml/render/tags/gallery.py
+++ b/wikitexthtml/render/tags/gallery.py
@@ -15,22 +15,22 @@ def hook(instance: WikiTextHtml, tag: wikitextparser.Tag):
             if value.endswith("px"):
                 value = value[:-2]
             if not value.isnumeric():
-                instance.add_error(f"Gallery attribute '{attr}' is not in pixels: {value}")
+                instance.add_error(f'Gallery attribute "{attr}" is not in pixels: {value}.')
             if attr == "widths":
                 widths = int(value)
             else:
                 heights = int(value)
         elif attr == "perrow":
             if not value.isnumeric():
-                instance.add_error(f"Gallery attribute '{attr}' is not in a number: {value}")
+                instance.add_error(f'Gallery attribute "{attr}" is not in a number: {value}.')
             perrow = int(value)
         elif attr == "caption":
             caption = value
         elif attr == "mode":
             if value != "traditional":
-                instance.add_error(f"Gallery attribute '{attr}' has an unsupported value: {value}")
+                instance.add_error(f'Gallery attribute "{attr}" has an unsupported value: {value}.')
         else:
-            instance.add_error(f"Gallery attribute '{attr}' is not a valid attribute")
+            instance.add_error(f'Gallery attribute "{attr}" is not a valid attribute.')
 
     if perrow:
         max_width = perrow * (widths + 43)
@@ -50,7 +50,7 @@ def hook(instance: WikiTextHtml, tag: wikitextparser.Tag):
 
         image, _, title = item.partition("|")
         if not image.lower().startswith("file:"):
-            instance.add_error(f"Gallery entry '{image}' is not a valid gallery entry")
+            instance.add_error(f'Gallery entry "{image}" is not a valid gallery entry.')
             continue
         image = image[5:]
 

--- a/wikitexthtml/render/template.py
+++ b/wikitexthtml/render/template.py
@@ -5,16 +5,22 @@ from . import (
     parameter,
     parser_function,
 )
+from ..exceptions import InvalidTemplate
 from ..prototype import WikiTextHtml
 
 
 def _render_template(instance: WikiTextHtml, template: wikitextparser.Template):
     name = template.name.strip()
 
-    instance._templates.add(name)
+    try:
+        if not instance.template_exists(name):
+            instance.add_error(f'Template "{name}" does not exist.')
+    except InvalidTemplate as e:
+        # Errors always end with a dot, hence the [:-1].
+        instance.add_error(f'{e.args[0][:-1]} (template "{{{{{name}}}}}").')
+        return
 
-    if not instance.template_exists(name):
-        instance.add_error(f"Template '{name}' does not exist")
+    instance._templates.add(name)
 
     body = instance.template_load(name)
     body = preprocess.begin(instance, body, is_transcluding=True)

--- a/wikitexthtml/render/wikilink.py
+++ b/wikitexthtml/render/wikilink.py
@@ -27,7 +27,7 @@ def replace(instance: WikiTextHtml, wikitext: wikitextparser.WikiText):
             if namespace:
                 if namespace not in WIKILINK_NAMESPACES:
                     instance.add_error(
-                        f"Namespace '{namespace}' in wikilink '{wikilink.title}' is an unknown namespace"
+                        f'Namespace "{namespace}" is an unknown namespace (wikilink "{wikilink.string}").'
                     )
                     continue
 

--- a/wikitexthtml/render/wikilinks/internal.py
+++ b/wikitexthtml/render/wikilinks/internal.py
@@ -2,12 +2,18 @@ import html
 import urllib
 import wikitextparser
 
+from ...exceptions import InvalidWikiLink
 from ...prototype import WikiTextHtml
 
 
 def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
     url = wikilink.title.strip()
-    title = instance.clean_title(url)
+    try:
+        title = instance.clean_title(url)
+    except InvalidWikiLink as e:
+        # Errors always end with a dot, hence the [:-1].
+        instance.add_error(f'{e.args[0][:-1]} (wikilink "{wikilink.string}").')
+        return
 
     if wikilink.text is None:
         text = title
@@ -26,7 +32,7 @@ def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
     link_extra = ""
 
     if url and not instance.page_exists(url):
-        instance.add_error(f"Linked page '{wikilink.title}' does not exist")
+        instance.add_error(f'Linked page "{wikilink.title}"" does not exist (wikilink "{wikilink.string}").')
         link_extra = ' class="new"'
 
     hash = ""


### PR DESCRIPTION
If for example you don't accept " in a [[]], you can now raise a
InvalidWikiLink on "clean_title()", which will prevent the [[]]
from rendering.

While at it, made the errors a lot more consistent.