### PR TITLE
Fix: remove "media" from this library

### DIFF
--- a/wikitexthtml/render/wikilink.py
+++ b/wikitexthtml/render/wikilink.py
@@ -8,7 +8,6 @@ from ..prototype import WikiTextHtml
 
 WIKILINK_NAMESPACES = {
     "file": file.replace,
-    "media": file.replace,
 }
 
 

--- a/wikitexthtml/render/wikilinks/file.py
+++ b/wikitexthtml/render/wikilinks/file.py
@@ -13,14 +13,10 @@ from ...prototype import WikiTextHtml
 
 def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
     is_image = False
-    is_media = False
 
     if wikilink.title.lower().startswith("file:"):
         filename = wikilink.title[5:]
         is_image = True
-    elif wikilink.title.lower().startswith("media:"):
-        filename = wikilink.title[6:]
-        is_media = True
     else:
         raise NotImplementedError(f"Unknown wikilink file {wikilink.title}")
 
@@ -137,8 +133,6 @@ def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
 
     if not frameless:
         extra_a += ' class="image"'
-    if is_media:
-        extra_a += ' class="internal"'
 
     if frameless:
         extra_a += f' title="{html.escape(title)}"'

--- a/wikitexthtml/render/wikilinks/internal.py
+++ b/wikitexthtml/render/wikilinks/internal.py
@@ -8,24 +8,24 @@ from ...prototype import WikiTextHtml
 
 def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
     url = wikilink.title.strip()
+
+    text = ""
+    # Always run clean_title() on the URL, as it detects URLs that are invalid
+    # because of invalid namespaces, etc.
     if url:
         try:
-            title = instance.clean_title(url)
+            text = instance.clean_title(url)
         except InvalidWikiLink as e:
             # Errors always end with a dot, hence the [:-1].
             instance.add_error(f'{e.args[0][:-1]} (wikilink "{wikilink.string}").')
             return
-    else:
-        title = ""
 
-    if wikilink.text is None:
-        text = title
-        if wikilink.fragment:
-            text += f"#{wikilink.fragment}"
-    else:
+    if wikilink.text:
         text = wikilink.text.strip()
+    elif wikilink.fragment:
+        text += f"#{wikilink.fragment}"
 
-    title = html.escape(title)
+    title = html.escape(wikilink.target)
     text = html.escape(text)
 
     if url == instance._page and not wikilink.fragment:


### PR DESCRIPTION
It is something the user of this library should implement, as it
should produce a link to the raw file. This is, like ":File", out
of scope of this library.