### PR TITLE
Fix: don't escape the title of a wikilink

### DIFF
--- a/wikitexthtml/render/wikilinks/internal.py
+++ b/wikitexthtml/render/wikilinks/internal.py
@@ -19,6 +19,7 @@ def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
             # Errors always end with a dot, hence the [:-1].
             instance.add_error(f'{e.args[0][:-1]} (wikilink "{wikilink.string}").')
             return
+        text = html.escape(text)
 
     if wikilink.text:
         text = wikilink.text.strip()
@@ -26,7 +27,6 @@ def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
         text += f"#{wikilink.fragment}"
 
     title = html.escape(wikilink.target)
-    text = html.escape(text)
 
     if url == instance._page and not wikilink.fragment:
         wikilink.string = f'<strong class="selflink">{text}</strong>'


### PR DESCRIPTION
Only escape it if it is generated from the URL. This is because
"&amp;" everywhere is rendered as "&", except for pagenames. In
other words:

[[en/&amp;]] should render "&amp;"
[[en/&amp;|&amp;]] should render as "&"