### PR TITLE
Change: Don't output duplicate ids for section headers.

### DIFF
--- a/wikitexthtml/render/section.py
+++ b/wikitexthtml/render/section.py
@@ -163,8 +163,7 @@ def replace(instance: WikiTextHtml, wikitext: wikitextparser.WikiText):
             title = section.title.strip()
 
             content = f"<h{section.level}>"
-            content += f'<a class="anchor" id="{slug}" href="#{slug}"></a>'
-            content += f'<a name="{slug}" id="{slug}"></a>'
+            content += f'<a class="anchor" href="#{slug}"></a>'
             content += f'<span class="mw-headline" id="{slug}">{title}</span>'
             content += f"</h{section.level}>\n"
         else:


### PR DESCRIPTION
As per https://web.dev/duplicate-id-active/, it is not recommended to have multiple elements with the same id.

This changes the output for each section so that the anchor element points to the span (since the span contains the useful information, and as such should be the target for screen readers). I also merged the two anchor elements into one.
