### PR TITLE
Add: optional syntax highlighting with pygments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.8',
+    python_requires=">=3.8",
     install_requires=[
+        "pygments",
         "python-slugify",
         "ply",
         "wikitextparser",

--- a/wikitexthtml/page.py
+++ b/wikitexthtml/page.py
@@ -30,8 +30,13 @@ class Page(WikiTextHtml):
         self._errors = []  # type: List[str]
         self._template_path = []  # type: List[str]
 
-    def prepare(self, body) -> wikitextparser.WikiText:
+    def prepare(self, body, enable_syntax_highlight=False) -> wikitextparser.WikiText:
         body = preprocess.begin(self, body)
+        if enable_syntax_highlight:
+            body = preprocess.highlight_syntax(self, body)
+        else:
+            body = preprocess.replace_syntax_highlight_with_pre(self, body)
+
         body = preprocess.pre_block(self, body)
         body = preprocess.hr_line(self, body)
 

--- a/wikitexthtml/render/wikilinks/file.py
+++ b/wikitexthtml/render/wikilinks/file.py
@@ -90,11 +90,26 @@ def replace(instance: WikiTextHtml, wikilink: wikitextparser.WikiLink):
                 if "x" in option:
                     width, _, height = option.partition("x")
                     if width:
-                        options["width"] = int(width)
-                    options["height"] = int(height)
+                        if not width.isnumeric():
+                            instance.add_error(
+                                f'Image "{wikilink.title}" sets width attribute but this is not a number: {width}.'
+                            )
+                        else:
+                            options["width"] = int(width)
+                    if not height.isnumeric():
+                        instance.add_error(
+                            f'Image "{wikilink.title}" sets height attribute but this is not a number: {height}.'
+                        )
+                    else:
+                        options["height"] = int(height)
                 else:
                     width = option
-                    options["width"] = int(width)
+                    if not width.isnumeric():
+                        instance.add_error(
+                            f'Image "{wikilink.title}" sets width attribute but this is not a number: {width}.'
+                        )
+                    else:
+                        options["width"] = int(width)
             elif option.startswith("link="):
                 options["link"] = option[5:]
                 options["title"] = option[5:]


### PR DESCRIPTION
This PR adds the option to render the [MediaWiki `<syntaxhighlight>` tag](https://www.mediawiki.org/wiki/Extension:SyntaxHighlight#Usage). Currently it supports the "lang" and "line <no>" options of the feature. Note that if `lang` is not supplied, the processor will make a best guess and highlight based on heuristics.

By default, anything downstream will not see any changed behavior. If downstream projects wish to use the new feature, they may do so by calling the `prepare()` method with the `should_color_syntax` argument set to `True`.

I have a companion PR ready for TrueWiki that will add this functionality and expose a setting in the `.truewiki.yml` file to toggle it. If toggled off, wikitexthtml converts any instances of `<syntaxhighlight></syntaxhighlight>` pairs to `<pre>` tags.

Here are some examples of what this looks like in practice:
* Syntax highlighting with default options
![code_ex_2_nolines](https://user-images.githubusercontent.com/14336407/161361653-53ad338a-9062-4071-a190-ffbedfabdd92.png)

* Syntax highlighting with `line` option
![code_ex_1](https://user-images.githubusercontent.com/14336407/161361651-9db835f7-8797-46fc-8a71-57f66d22a458.png)

* Syntax highlighting with `line 6800` option
![code_ex_3_anystart](https://user-images.githubusercontent.com/14336407/161361654-ffa5a500-3c2c-4fcf-a3e1-b97b7a48211f.png)

I should also note that without CSS, these blocks will look identical to `<pre>` blocks. `Pygments` has the ability to both output css styling to be piped to a file, or it can render it inline with the html.

The examples above were rendered with the following CSS (applied in a second file in addition to the default wiki css in TrueWiki): 
https://gist.github.com/Qrbaker/424bdd7d48b88557be1340eb208a7c6f