### PR TITLE
Fix: regex fails to capture certain langs

### DIFF
--- a/wikitexthtml/page.py
+++ b/wikitexthtml/page.py
@@ -88,9 +88,9 @@ class Page(WikiTextHtml):
 
         return postprocess.replace(self, wtp.string)
 
-    def render(self, body: str = None) -> "Page":
+    def render(self, body: str = None, enable_syntax_highlight=False) -> "Page":
         body = self.page_load(self._page)
-        wtp = self.prepare(body)
+        wtp = self.prepare(body, enable_syntax_highlight)
         self._html = self.render_page(wtp)
         return self
 

--- a/wikitexthtml/render/preprocess.py
+++ b/wikitexthtml/render/preprocess.py
@@ -18,7 +18,7 @@ NOWIKI_PATTERN = regex.compile(r"<nowiki>([\s\S]*?)(?></nowiki>|\Z)")
 ONLYINCLUDE_PATTERN = regex.compile(r"<onlyinclude>([\s\S]*?)(?></onlyinclude>|\Z)")
 PRE_PATTERN = regex.compile(r"<pre>([\s\S]*?)(?></pre>|\Z)")
 SYNTAXHIGHLIGHT_PATTERN = regex.compile(
-    r"<syntaxhighlight( lang=\")?(?P<lang>[a-zA-z]+)?\"?"
+    r"<syntaxhighlight( lang=\")?(?P<lang>[^\"]+)?\"?"
     r"(?P<line> line(?P<lineStart> \d*)?)?>(?P<code>[\s\S]*?)(?></syntaxhighlight>|\Z)"
 )
 

--- a/wikitexthtml/render/preprocess.py
+++ b/wikitexthtml/render/preprocess.py
@@ -18,8 +18,9 @@ NOWIKI_PATTERN = regex.compile(r"<nowiki>([\s\S]*?)(?></nowiki>|\Z)")
 ONLYINCLUDE_PATTERN = regex.compile(r"<onlyinclude>([\s\S]*?)(?></onlyinclude>|\Z)")
 PRE_PATTERN = regex.compile(r"<pre>([\s\S]*?)(?></pre>|\Z)")
 SYNTAXHIGHLIGHT_PATTERN = regex.compile(
-    r"<syntaxhighlight( lang=\")?(?P<lang>[^\"]+)?\"?"
-    r"(?P<line> line(?P<lineStart> \d*)?)?>(?P<code>[\s\S]*?)(?></syntaxhighlight>|\Z)"
+    r"<syntaxhighlight( lang=\"(?P<lang>[^\"]+)\")?"
+    r"(?P<line> line( start=\"(?P<lineStart>\d+)\")?)?>"
+    r"(?P<code>[\s\S]*?)(</syntaxhighlight>|\Z)"
 )
 
 


### PR DESCRIPTION
Small fix that I noticed when testing various languages today:


Languages with non alphanumeric characters (i.e. c++)
would not be captured by the regex for syntax highlighting.

This change moves from a positive capture (all alphanumeric
characters) to a negative capture (anything that is NOT a ").

This should be a more robust solution... at least until some-
one invents a language with a " in the name.