### PR TITLE
Fix: overlapping italic / bold could case exception

### DIFF
--- a/tests/test_bold_italic.py
+++ b/tests/test_bold_italic.py
@@ -10,3 +10,14 @@ def test_bold_and_italic():
             return True
 
     assert PageTest("Test").render().html == "<p><i>i</i> - <b>b</b> - <i><b>ib</b></i></p>"
+
+
+def test_overlapping_bold_and_italic():
+    class PageTest(Page):
+        def page_load(self, page: str) -> str:
+            return "''a''' ''b'' zz'''c''"
+
+        def page_exists(self, page: str) -> bool:
+            return True
+
+    assert PageTest("Test").render().html == "<i>a<b></i>b<i>zz</b>c</i>"

--- a/wikitexthtml/render/bold_and_italic.py
+++ b/wikitexthtml/render/bold_and_italic.py
@@ -5,7 +5,13 @@ from ..prototype import WikiTextHtml
 
 def replace(instance: WikiTextHtml, wikitext: wikitextparser.WikiText):
     for bold in reversed(wikitext.get_bolds(recursive=True)):
-        bold.string = f"<b>{bold.text.strip()}</b>"
+        # Replace the closing tag with a placeholder, of the exact same length
+        # as the original text ('''). This makes sure the italic tags are still
+        # in the same place.
+        bold.string = f"<b>{bold.text.strip()}<B>"
 
     for italic in reversed(wikitext.get_italics(recursive=True)):
         italic.string = f"<i>{italic.text.strip()}</i>"
+
+    # Replace the placeholders with the closing tags.
+    wikitext.string = wikitext.string.replace("<B>", "</b>")


### PR DESCRIPTION
Take the string:

`''a''' ''b'' zz'''c''`

Here the bold and italic are overlapping. The Bold part is:

`''' ''b'' zz'''`

The Italic parts are:

`''a''' ''` and `'' zz'''c''`

The problem here is that while replacing the first, the internal shadow variable of the last Italic part is no longer matching the actual string. The `zz` gives just enough offset, that the `match` on the last Italic object now returns `None`, instead of the actual match.

This can be solved by first replacing the closing tag of the Bold with something that is of equal size than the closing string, so: three characters. That way the shadow of the Italic entries remain correct, and replacement works out fine.

In all of the cases we have seen this so far, it was always user-error for having unbalanced `'`, but that shouldn't cause a crash, ofc.