### PR TITLE
Fix: don't throw exception on parser-functions with wrong argument count

### DIFF
--- a/wikitexthtml/render/parser_functions/exceptions.py
+++ b/wikitexthtml/render/parser_functions/exceptions.py
@@ -1,6 +1,2 @@
-class ParserFunctionWrongArgumentCount(Exception):
-    """Parser function got wrong amount of arguments."""
-
-
 class EvaluationError(Exception):
     """Evaluation of the expression failed."""

--- a/wikitexthtml/render/parser_functions/expr.py
+++ b/wikitexthtml/render/parser_functions/expr.py
@@ -1,9 +1,6 @@
 import wikitextparser
 
-from .exceptions import (
-    EvaluationError,
-    ParserFunctionWrongArgumentCount,
-)
+from .exceptions import EvaluationError
 from .helpers import (
     evaluate,
     get_argument,
@@ -13,7 +10,11 @@ from ...prototype import WikiTextHtml
 
 def expr(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) < 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects at least argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     expr = get_argument(parser_function, 0)
 

--- a/wikitexthtml/render/parser_functions/if_.py
+++ b/wikitexthtml/render/parser_functions/if_.py
@@ -1,13 +1,16 @@
 import wikitextparser
 
-from .exceptions import ParserFunctionWrongArgumentCount
 from .helpers import get_argument
 from ...prototype import WikiTextHtml
 
 
 def if_(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) < 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects at least 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     condition = get_argument(parser_function, 0)
 

--- a/wikitexthtml/render/parser_functions/ifeq.py
+++ b/wikitexthtml/render/parser_functions/ifeq.py
@@ -1,6 +1,5 @@
 import wikitextparser
 
-from .exceptions import ParserFunctionWrongArgumentCount
 from .helpers import get_argument
 from ...prototype import WikiTextHtml
 
@@ -10,7 +9,11 @@ def ifeq(
     parser_function: wikitextparser.ParserFunction,
 ):
     if len(parser_function.arguments) < 2:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects at least 2 arguments, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     left = get_argument(parser_function, 0)
     right = get_argument(parser_function, 1)

--- a/wikitexthtml/render/parser_functions/ifexist.py
+++ b/wikitexthtml/render/parser_functions/ifexist.py
@@ -1,13 +1,16 @@
 import wikitextparser
 
-from .exceptions import ParserFunctionWrongArgumentCount
 from .helpers import get_argument
 from ...prototype import WikiTextHtml
 
 
 def ifexist(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) < 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects at least 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     page_title = get_argument(parser_function, 0)
     page_exists = instance.page_exists(page_title)

--- a/wikitexthtml/render/parser_functions/ifexpr.py
+++ b/wikitexthtml/render/parser_functions/ifexpr.py
@@ -1,9 +1,6 @@
 import wikitextparser
 
-from .exceptions import (
-    EvaluationError,
-    ParserFunctionWrongArgumentCount,
-)
+from .exceptions import EvaluationError
 from .helpers import (
     evaluate,
     get_argument,
@@ -13,7 +10,11 @@ from ...prototype import WikiTextHtml
 
 def ifexpr(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) < 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects at least 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     expr = get_argument(parser_function, 0)
 

--- a/wikitexthtml/render/parser_functions/string.py
+++ b/wikitexthtml/render/parser_functions/string.py
@@ -1,13 +1,16 @@
 import wikitextparser
 
-from .exceptions import ParserFunctionWrongArgumentCount
 from .helpers import get_argument
 from ...prototype import WikiTextHtml
 
 
 def lc(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) != 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     value = get_argument(parser_function, 0).lower()
     parser_function.string = value
@@ -15,7 +18,11 @@ def lc(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
 
 def uc(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) != 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     value = get_argument(parser_function, 0).upper()
     parser_function.string = value
@@ -23,7 +30,11 @@ def uc(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
 
 def lcfirst(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) != 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     value = get_argument(parser_function, 0)
     parser_function.string = value[0].lower() + value[1:]
@@ -31,7 +42,11 @@ def lcfirst(instance: WikiTextHtml, parser_function: wikitextparser.ParserFuncti
 
 def ucfirst(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) != 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     value = get_argument(parser_function, 0)
     parser_function.string = value[0].upper() + value[1:]

--- a/wikitexthtml/render/parser_functions/switch.py
+++ b/wikitexthtml/render/parser_functions/switch.py
@@ -1,13 +1,16 @@
 import wikitextparser
 
-from .exceptions import ParserFunctionWrongArgumentCount
 from .helpers import get_argument
 from ...prototype import WikiTextHtml
 
 
 def switch(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) < 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects at least 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     branch = get_argument(parser_function, 0).strip()
 

--- a/wikitexthtml/render/parser_functions/url.py
+++ b/wikitexthtml/render/parser_functions/url.py
@@ -2,14 +2,17 @@ import html
 import urllib
 import wikitextparser
 
-from .exceptions import ParserFunctionWrongArgumentCount
 from .helpers import get_argument
 from ...prototype import WikiTextHtml
 
 
 def encode(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) != 1:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects 1 argument, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     url = get_argument(parser_function, 0).strip()
 

--- a/wikitexthtml/render/parser_functions/variables.py
+++ b/wikitexthtml/render/parser_functions/variables.py
@@ -2,14 +2,17 @@ import datetime
 import html
 import wikitextparser
 
-from .exceptions import ParserFunctionWrongArgumentCount
 from ...exceptions import InvalidWikiLink
 from ...prototype import WikiTextHtml
 
 
 def variable(instance: WikiTextHtml, parser_function: wikitextparser.ParserFunction):
     if len(parser_function.arguments) != 0:
-        raise ParserFunctionWrongArgumentCount
+        instance.add_error(
+            f'Parser function "{parser_function.name}" expects no arguments, '
+            f"but {len(parser_function.arguments)} given."
+        )
+        return
 
     name = parser_function.name.lower()
     if name == "currentyear":


### PR DESCRIPTION
This is user-input, and throwing exceptions is not really user-friendly.